### PR TITLE
OrgFoldingProvider matches lines starting with bold text

### DIFF
--- a/src/org-folding-provider.ts
+++ b/src/org-folding-provider.ts
@@ -19,7 +19,7 @@ export class OrgFoldingProvider implements FoldingRangeProvider {
             const element = document.lineAt(lineNumber);
             const text = element.text;
 
-            if (!text.startsWith("*")) {
+            if (!text.match(/^\*+ /)) {
                 continue;
             }
 


### PR DESCRIPTION
OrgFoldingProvider matches some lines that are not headers, like in following:

```org
* Correct header
but the following
*bold text* is not an header
```